### PR TITLE
fix: typo

### DIFF
--- a/dicts/dict_en.po
+++ b/dicts/dict_en.po
@@ -180,7 +180,7 @@ msgstr ""
 msgid "Cannot load file"
 msgstr ""
 
-msgid "Cannot load msdia library"
+msgid "Cannot load media library"
 msgstr ""
 
 msgid "Cannot open file"


### PR DESCRIPTION
Hello @horsicq 
There was a small typo: `msdia` instead of `media`

I have only fixed the English po file but that typo resides in all po files. Please check.

Cya