### PR TITLE
German: Unify spellings of bit sizes

### DIFF
--- a/dicts/dict_de.po
+++ b/dicts/dict_de.po
@@ -20,7 +20,7 @@ msgid "16-bit"
 msgstr "16-Bit"
 
 msgid "256-bit"
-msgstr "256-bit"
+msgstr "256-Bit"
 
 msgid "32-bit"
 msgstr "32-Bit"
@@ -29,7 +29,7 @@ msgid "64-bit"
 msgstr "64-Bit"
 
 msgid "8-bit"
-msgstr "8 Bit"
+msgstr "8-Bit"
 
 msgid "API key"
 msgstr "API-Schlüssel"


### PR DESCRIPTION
This updates the German translation to use the same spelling for all bit sizes (8-Bit – 256-Bit).