### PR TITLE
Finish zh-TW translation

### DIFF
--- a/dicts/dict_zh-TW.po
+++ b/dicts/dict_zh-TW.po
@@ -148,7 +148,7 @@ msgid "Breakpoints"
 msgstr "斷點"
 
 msgid "Buffer size"
-msgstr ""
+msgstr "緩衝區大小"
 
 msgid "Bugreports"
 msgstr "錯誤報告"
@@ -181,13 +181,13 @@ msgid "Cancel"
 msgstr "取消"
 
 msgid "Cannot find"
-msgstr ""
+msgstr "找不到"
 
 msgid "Cannot find file"
 msgstr "找不到檔案"
 
 msgid "Cannot fix dump file"
-msgstr ""
+msgstr "無法修復轉存檔案"
 
 msgid "Cannot get PDB age"
 msgstr "無法獲取 PDB 年齡"
@@ -208,7 +208,7 @@ msgid "Cannot load file"
 msgstr "無法加載文件"
 
 msgid "Cannot open dump file"
-msgstr ""
+msgstr "無法打開轉存檔案"
 
 msgid "Cannot open file"
 msgstr "無法打開檔案"
@@ -217,7 +217,7 @@ msgid "Cannot open session"
 msgstr "無法打開會話"
 
 msgid "Cannot read file"
-msgstr ""
+msgstr "無法讀取檔案"
 
 msgid "Cannot read memory at address"
 msgstr "無法讀取地址處的內存"
@@ -232,7 +232,7 @@ msgid "Cannot set shortcut"
 msgstr "無法設置捷徑"
 
 msgid "Cannot write data to file"
-msgstr ""
+msgstr "無法將資料寫入檔案"
 
 msgid "Certificate"
 msgstr "證書"
@@ -301,7 +301,7 @@ msgid "Create view model"
 msgstr "建立視圖模型"
 
 msgid "Crypter"
-msgstr ""
+msgstr 加密器""
 
 msgid "Cryptor"
 msgstr "加密器"
@@ -310,7 +310,7 @@ msgid "Cursor"
 msgstr "目前位址"
 
 msgid "Custom"
-msgstr ""
+msgstr "自訂"
 
 msgid "Custom database"
 msgstr "自訂資料庫"
@@ -331,7 +331,7 @@ msgid "Database"
 msgstr "資料庫"
 
 msgid "Databases"
-msgstr ""
+msgstr "資料庫"
 
 msgid "Date"
 msgstr "日期"
@@ -367,7 +367,7 @@ msgid "Dependencies"
 msgstr "依賴關係"
 
 msgid "Description"
-msgstr ""
+msgstr "描述"
 
 msgid "Detach"
 msgstr "分離"
@@ -400,7 +400,7 @@ msgid "Donate"
 msgstr "贊助"
 
 msgid "Driver"
-msgstr "司機"
+msgstr "驅動程式"
 
 msgid "Dump"
 msgstr "轉存"
@@ -448,7 +448,7 @@ msgid "Exit"
 msgstr "退出"
 
 msgid "Export"
-msgstr "出口"
+msgstr "導出"
 
 msgid "Export File Name"
 msgstr "導出文件名"
@@ -460,10 +460,10 @@ msgid "External references"
 msgstr "外部參考"
 
 msgid "Extra"
-msgstr ""
+msgstr "外部"
 
 msgid "Extra database"
-msgstr ""
+msgstr "外部資料庫"
 
 msgid "Extract"
 msgstr "擷取"
@@ -535,7 +535,7 @@ msgid "Follow me"
 msgstr ""
 
 msgid "Fonts"
-msgstr ""
+msgstr "字型"
 
 msgid "Footer"
 msgstr ""
@@ -571,7 +571,7 @@ msgid "Get"
 msgstr "獲取"
 
 msgid "Get IAT"
-msgstr ""
+msgstr "獲取 IAT"
 
 msgid "Get element"
 msgstr "獲取元素"
@@ -628,7 +628,7 @@ msgid "Hex"
 msgstr "十六進制"
 
 msgid "Hide unknown"
-msgstr ""
+msgstr "隱藏未知"
 
 msgid "Highlight"
 msgstr "標記"
@@ -646,7 +646,7 @@ msgid "Import"
 msgstr "進口"
 
 msgid "Import hash"
-msgstr "導入哈希"
+msgstr "導入雜湊"
 
 msgid "Indirect symbols"
 msgstr "間接符號"
@@ -676,16 +676,16 @@ msgid "Invalid"
 msgstr "無效"
 
 msgid "Invalid address of entry point"
-msgstr ""
+msgstr "無效的入口點位址"
 
 msgid "Invalid font"
-msgstr ""
+msgstr "無效的字型"
 
 msgid "Invalid handle"
 msgstr ""
 
 msgid "Invalid offset"
-msgstr ""
+msgstr "無效的偏移"
 
 msgid "Invalid opcode"
 msgstr "無效的操作碼"
@@ -754,7 +754,7 @@ msgid "Load config"
 msgstr "加載配置"
 
 msgid "Loader"
-msgstr ""
+msgstr "載入器"
 
 msgid "Local relocation"
 msgstr "本地搬遷"
@@ -814,19 +814,19 @@ msgid "Metadata"
 msgstr "元數據"
 
 msgid "Metadata table"
-msgstr ""
+msgstr "元數據表"
 
 msgid "Method"
 msgstr "方法"
 
 msgid "Methods"
-msgstr ""
+msgstr "方法"
 
 msgid "MiB"
 msgstr "MiB"
 
 msgid "Min length"
-msgstr ""
+msgstr "最小長度"
 
 msgid "Mode"
 msgstr "模式"
@@ -838,7 +838,7 @@ msgid "More info"
 msgstr "更多信息"
 
 msgid "Multiplatform"
-msgstr ""
+msgstr "跨平台"
 
 msgid "Multisearch"
 msgstr "多重搜尋"
@@ -868,13 +868,13 @@ msgid "No update available"
 msgstr "無可用的更新"
 
 msgid "None"
-msgstr ""
+msgstr "無"
 
 msgid "Nothing found"
 msgstr "沒有找到"
 
 msgid "Null-terminated"
-msgstr ""
+msgstr "以空字元結尾"
 
 msgid "Number"
 msgstr "數字"
@@ -889,7 +889,7 @@ msgid "Object"
 msgstr "物件"
 
 msgid "Objects"
-msgstr ""
+msgstr "物件"
 
 msgid "Offset"
 msgstr "偏移"
@@ -925,7 +925,7 @@ msgid "Options"
 msgstr "選項"
 
 msgid "Output"
-msgstr ""
+msgstr "輸出"
 
 msgid "Overlay"
 msgstr "覆蓋"
@@ -937,7 +937,7 @@ msgid "Packer"
 msgstr "封隔器"
 
 msgid "Patch"
-msgstr ""
+msgstr "修補"
 
 msgid "Pause"
 msgstr "暫停"
@@ -952,7 +952,7 @@ msgid "Plain Text"
 msgstr ""
 
 msgid "Platform"
-msgstr ""
+msgstr "平台"
 
 msgid "Player"
 msgstr "播放器"
@@ -1045,7 +1045,7 @@ msgid "Registers"
 msgstr "暫存器"
 
 msgid "Regular expression"
-msgstr ""
+msgstr "正規表達式"
 
 msgid "Relative address"
 msgstr "相對位址"
@@ -1081,7 +1081,7 @@ msgid "Result"
 msgstr "結果"
 
 msgid "Rule name"
-msgstr ""
+msgstr "規則名稱"
 
 msgid "Rules"
 msgstr "規則"
@@ -1090,7 +1090,7 @@ msgid "Run"
 msgstr "執行"
 
 msgid "Run path"
-msgstr ""
+msgstr "執行目錄"
 
 msgid "Running"
 msgstr "正在執行"
@@ -1132,10 +1132,10 @@ msgid "Scan after open"
 msgstr "打開後掃描"
 
 msgid "Scan engine"
-msgstr ""
+msgstr "掃描引擎"
 
 msgid "Scan for IAT"
-msgstr ""
+msgstr "搜尋 IAT"
 
 msgid "Schema"
 msgstr ""
@@ -1144,7 +1144,7 @@ msgid "Script"
 msgstr "腳本"
 
 msgid "Scripts"
-msgstr ""
+msgstr "腳本"
 
 msgid "Search"
 msgstr "搜尋"
@@ -1159,13 +1159,13 @@ msgid "Search signatures"
 msgstr "搜尋簽名"
 
 msgid "Search string"
-msgstr ""
+msgstr "搜尋字串"
 
 msgid "Search strings"
-msgstr "搜索字串"
+msgstr "搜尋字串"
 
 msgid "Search value"
-msgstr ""
+msgstr "搜尋值"
 
 msgid "Search values"
 msgstr "搜尋值"
@@ -1225,7 +1225,7 @@ msgid "Show in"
 msgstr ""
 
 msgid "Show info"
-msgstr ""
+msgstr "顯示資訊"
 
 msgid "Show logo"
 msgstr "顯示徽標"
@@ -1246,7 +1246,7 @@ msgid "Signature"
 msgstr "簽章"
 
 msgid "Signature name"
-msgstr ""
+msgstr "簽章名稱"
 
 msgid "Signatures"
 msgstr "簽章"
@@ -1264,7 +1264,7 @@ msgid "Size of image"
 msgstr "圖片尺寸"
 
 msgid "Sort"
-msgstr ""
+msgstr "排序"
 
 msgid "Sort elements"
 msgstr "排序元素"
@@ -1273,7 +1273,7 @@ msgid "Sort type"
 msgstr "排序類型"
 
 msgid "Sorted"
-msgstr ""
+msgstr "已排序"
 
 msgid "Source code"
 msgstr "源代碼"
@@ -1318,7 +1318,7 @@ msgid "Struct"
 msgstr "結構"
 
 msgid "Struct and unions"
-msgstr "結構體和工會"
+msgstr "結構和聯合"
 
 msgid "Structs"
 msgstr "結構"
@@ -1360,19 +1360,19 @@ msgid "Table views"
 msgstr ""
 
 msgid "Tags"
-msgstr ""
+msgstr "標籤"
 
 msgid "Text"
 msgstr "文字"
 
 msgid "Text documents"
-msgstr "文件檔"
+msgstr "文字檔"
 
 msgid "Text editors"
-msgstr ""
+msgstr "文字編輯器"
 
 msgid "Text files"
-msgstr "文本檔案"
+msgstr "文字檔案"
 
 msgid "Thanks"
 msgstr "特別感謝"
@@ -1423,13 +1423,13 @@ msgid "Total"
 msgstr "總計"
 
 msgid "Trace"
-msgstr ""
+msgstr "追蹤"
 
 msgid "Trace into"
-msgstr ""
+msgstr "步入"
 
 msgid "Trace over"
-msgstr ""
+msgstr "步過"
 
 msgid "Tree"
 msgstr "樹狀圖"
@@ -1447,10 +1447,10 @@ msgid "Type"
 msgstr "類型"
 
 msgid "Unicode"
-msgstr ""
+msgstr "Unicode"
 
 msgid "Universal"
-msgstr ""
+msgstr "通用的"
 
 msgid "Unknown"
 msgstr "未知"
@@ -1528,10 +1528,10 @@ msgid "Write error"
 msgstr "寫入錯誤"
 
 msgid "Zeros"
-msgstr ""
+msgstr "零"
 
 msgid "Zoom"
-msgstr ""
+msgstr "縮放"
 
 msgid "compressor"
 msgstr "壓縮軟件"
@@ -1565,7 +1565,3 @@ msgstr "保護"
 
 msgid "true"
 msgstr "true"
-
-
-
-

--- a/dicts/dict_zh-TW.po
+++ b/dicts/dict_zh-TW.po
@@ -7,22 +7,22 @@ msgstr ""
 "X-Language: zh_TW\n"
 
 msgid "128-bit"
-msgstr "128位"
+msgstr "128位元"
 
 msgid "16-bit"
-msgstr "16位"
+msgstr "16位元"
 
 msgid "256-bit"
-msgstr "256位"
+msgstr "256位元"
 
 msgid "32-bit"
-msgstr "32位"
+msgstr "32位元"
 
 msgid "64-bit"
-msgstr "64位"
+msgstr "64位元"
 
 msgid "8-bit"
-msgstr "8位"
+msgstr "8位元"
 
 msgid "API key"
 msgstr "API金鑰"
@@ -31,16 +31,16 @@ msgid "About"
 msgstr "關於"
 
 msgid "Action"
-msgstr "行為"
+msgstr "動作"
 
 msgid "Add"
-msgstr "添加"
+msgstr "新增"
 
 msgid "Add alignment"
-msgstr "添加對齊"
+msgstr "新增對齊"
 
 msgid "Add to context menu"
-msgstr "添加到上下文菜單"
+msgstr "新增到上下文菜單"
 
 msgid "Address"
 msgstr "位址"
@@ -49,10 +49,10 @@ msgid "Advanced"
 msgstr "進階"
 
 msgid "Aggressive scan"
-msgstr ""
+msgstr "激進掃描"
 
 msgid "Algorithm"
-msgstr "算法"
+msgstr "演算法"
 
 msgid "All"
 msgstr "所有"
@@ -88,7 +88,7 @@ msgid "Are you sure?"
 msgstr "你確定嗎？"
 
 msgid "Array"
-msgstr "大批"
+msgstr "陣列"
 
 msgid "Arrows"
 msgstr "箭頭"
@@ -97,7 +97,7 @@ msgid "Attach"
 msgstr "附"
 
 msgid "Audio"
-msgstr "音頻"
+msgstr "音檔"
 
 msgid "Automatic"
 msgstr "自動"
@@ -112,7 +112,7 @@ msgid "Begin"
 msgstr "開始"
 
 msgid "Binary"
-msgstr ""
+msgstr "二進位"
 
 msgid "Bind"
 msgstr "綁定"
@@ -124,19 +124,19 @@ msgid "Bits"
 msgstr "位元"
 
 msgid "Block size"
-msgstr "代碼塊大小"
+msgstr "區塊大小"
 
 msgid "Bookmark"
 msgstr "書籤"
 
 msgid "Bookmarks"
-msgstr "書籤"
+msgstr "書籤集"
 
 msgid "Boot application"
-msgstr "啟動應用程序"
+msgstr "啟動應用程式"
 
 msgid "Boot service driver"
-msgstr "引導服務驅動程序"
+msgstr "引導服務驅動程式"
 
 msgid "Bound import"
 msgstr "綁定導入"
@@ -190,7 +190,7 @@ msgid "Cannot fix dump file"
 msgstr "無法修復轉存檔案"
 
 msgid "Cannot get PDB age"
-msgstr "無法獲取 PDB 年齡"
+msgstr "無法獲取 PDB 年份"
 
 msgid "Cannot get PDB name"
 msgstr "無法獲取 PDB 名稱"
@@ -205,7 +205,7 @@ msgid "Cannot load database"
 msgstr "無法加載數據庫"
 
 msgid "Cannot load file"
-msgstr "無法加載文件"
+msgstr "無法加載檔案"
 
 msgid "Cannot open dump file"
 msgstr "無法打開轉存檔案"
@@ -214,22 +214,22 @@ msgid "Cannot open file"
 msgstr "無法打開檔案"
 
 msgid "Cannot open session"
-msgstr "無法打開會話"
+msgstr "無法打開工作階段"
 
 msgid "Cannot read file"
 msgstr "無法讀取檔案"
 
 msgid "Cannot read memory at address"
-msgstr "無法讀取地址處的內存"
+msgstr "無法讀取位址處的記憶體"
 
 msgid "Cannot resize"
-msgstr "無法縮放大小"
+msgstr "無法調整大小"
 
 msgid "Cannot save file"
 msgstr "無法保存檔案"
 
 msgid "Cannot set shortcut"
-msgstr "無法設置捷徑"
+msgstr "無法設置快捷鍵"
 
 msgid "Cannot write data to file"
 msgstr "無法將資料寫入檔案"
@@ -283,7 +283,7 @@ msgid "Console"
 msgstr "系統控制臺"
 
 msgid "Controls"
-msgstr ""
+msgstr "控制項"
 
 msgid "Converter"
 msgstr "轉換器"
@@ -307,13 +307,13 @@ msgid "Cryptor"
 msgstr "加密器"
 
 msgid "Cursor"
-msgstr "目前位址"
+msgstr "鼠標"
 
 msgid "Custom"
-msgstr "自訂"
+msgstr "自定義"
 
 msgid "Custom database"
-msgstr "自訂資料庫"
+msgstr "自訂數據庫"
 
 msgid "Data"
 msgstr "資料"
@@ -328,10 +328,10 @@ msgid "Data inspector"
 msgstr "資料檢驗器"
 
 msgid "Database"
-msgstr "資料庫"
+msgstr "數據庫"
 
 msgid "Databases"
-msgstr "資料庫"
+msgstr "數據庫"
 
 msgid "Date"
 msgstr "日期"
@@ -340,10 +340,10 @@ msgid "Debug"
 msgstr "除錯"
 
 msgid "Debug data"
-msgstr "調試數據"
+msgstr "除錯數據"
 
 msgid "Debug registers"
-msgstr "調試暫存器"
+msgstr "除錯暫存器"
 
 msgid "Debugger"
 msgstr "除錯器"
@@ -355,7 +355,7 @@ msgid "Deep scan"
 msgstr "深層掃描"
 
 msgid "Default"
-msgstr "默認"
+msgstr "預設"
 
 msgid "Delay import"
 msgstr "延遲導入"
@@ -391,13 +391,13 @@ msgid "Disasm"
 msgstr "反組譯"
 
 msgid "Document"
-msgstr "檔案"
+msgstr "文檔"
 
 msgid "Documents"
-msgstr "檔案"
+msgstr "文檔"
 
 msgid "Donate"
-msgstr "贊助"
+msgstr "捐贈"
 
 msgid "Driver"
 msgstr "驅動程式"
@@ -451,19 +451,19 @@ msgid "Export"
 msgstr "導出"
 
 msgid "Export File Name"
-msgstr "導出文件名"
+msgstr "導出檔案名稱"
 
 msgid "Export type"
-msgstr "出口類型"
+msgstr "導出類型"
 
 msgid "External references"
 msgstr "外部參考"
 
 msgid "Extra"
-msgstr "外部"
+msgstr "附加"
 
 msgid "Extra database"
-msgstr "外部資料庫"
+msgstr "附加數據庫"
 
 msgid "Extract"
 msgstr "擷取"
@@ -490,7 +490,7 @@ msgid "File offset"
 msgstr "檔案偏移量"
 
 msgid "File saved"
-msgstr "文件已保存"
+msgstr "檔案已保存"
 
 msgid "File scan"
 msgstr "檔案掃描"
@@ -502,16 +502,16 @@ msgid "File type"
 msgstr "檔案類型"
 
 msgid "Files"
-msgstr "文件"
+msgstr "檔案"
 
 msgid "Filter"
 msgstr "過濾"
 
 msgid "Find"
-msgstr "搜尋"
+msgstr "尋找"
 
 msgid "First"
-msgstr ""
+msgstr "第一個"
 
 msgid "Fix offsets"
 msgstr "修復偏移"
@@ -529,16 +529,16 @@ msgid "Folder"
 msgstr "資料夾"
 
 msgid "Follow in"
-msgstr ""
+msgstr "跟進"
 
 msgid "Follow me"
-msgstr ""
+msgstr "追蹤我"
 
 msgid "Fonts"
-msgstr "字型"
+msgstr "字體"
 
 msgid "Footer"
-msgstr ""
+msgstr "頁腳"
 
 msgid "Form"
 msgstr "表單"
@@ -589,13 +589,13 @@ msgid "Go to download page?"
 msgstr "要跳轉至下載頁面嗎？"
 
 msgid "Gradient"
-msgstr ""
+msgstr "梯度"
 
 msgid "Grid"
 msgstr "網格"
 
 msgid "Group"
-msgstr ""
+msgstr "群組"
 
 msgid "Handles"
 msgstr "控制代碼"
@@ -622,7 +622,7 @@ msgid "Heuristic scan"
 msgstr "啟發式掃描"
 
 msgid "Heuristics"
-msgstr ""
+msgstr "啟發式"
 
 msgid "Hex"
 msgstr "十六進制"
@@ -637,10 +637,10 @@ msgid "Highlights"
 msgstr "標記"
 
 msgid "Image"
-msgstr "映像檔"
+msgstr "映像"
 
 msgid "Images"
-msgstr "影像"
+msgstr "映像"
 
 msgid "Import"
 msgstr "進口"
@@ -661,16 +661,16 @@ msgid "Input"
 msgstr "輸入"
 
 msgid "Installer"
-msgstr "安裝程序"
+msgstr "安裝程式"
 
 msgid "Installer data"
-msgstr "安裝人員數據"
+msgstr "安裝程式資料"
 
 msgid "Instruction pointer register"
 msgstr "指令指標暫存器"
 
 msgid "Interpreter"
-msgstr "口譯員"
+msgstr "直譯器"
 
 msgid "Invalid"
 msgstr "無效"
@@ -679,10 +679,10 @@ msgid "Invalid address of entry point"
 msgstr "無效的入口點位址"
 
 msgid "Invalid font"
-msgstr "無效的字型"
+msgstr "無效的字體"
 
 msgid "Invalid handle"
-msgstr ""
+msgstr "無效的控制代碼"
 
 msgid "Invalid offset"
 msgstr "無效的偏移"
@@ -703,7 +703,7 @@ msgid "Joiner"
 msgstr "合併工具"
 
 msgid "Jumps"
-msgstr "跳數"
+msgstr "跳轉"
 
 msgid "Keep size"
 msgstr "保持相同的大小"
@@ -721,43 +721,43 @@ msgid "Language"
 msgstr "語言"
 
 msgid "Last"
-msgstr ""
+msgstr "最後"
 
 msgid "Lazy binding"
-msgstr "懶惰綁定"
+msgstr "延遲綁定"
 
 msgid "Length"
 msgstr "長度"
 
 msgid "Libraries"
-msgstr "函示庫"
+msgstr "函式庫"
 
 msgid "Library"
-msgstr "函示庫"
+msgstr "函式庫"
 
 msgid "Library name"
-msgstr "圖書館名稱"
+msgstr "函式庫名稱"
 
 msgid "Licensing"
-msgstr ""
+msgstr "許可證"
 
 msgid "Linker"
-msgstr "鏈接器"
+msgstr "鏈結器"
 
 msgid "Links"
-msgstr "連結"
+msgstr "鏈結"
 
 msgid "List"
 msgstr "列表"
 
 msgid "Load config"
-msgstr "加載配置"
+msgstr "加載設定"
 
 msgid "Loader"
 msgstr "載入器"
 
 msgid "Local relocation"
-msgstr "本地搬遷"
+msgstr "局部重定位"
 
 msgid "Location"
 msgstr "位置"
@@ -769,40 +769,40 @@ msgid "MB"
 msgstr "MB"
 
 msgid "Main"
-msgstr ""
+msgstr "主要"
 
 msgid "Main module"
-msgstr ""
+msgstr "主模組"
 
 msgid "MainWindow"
-msgstr "主窗口"
+msgstr "主視窗"
 
 msgid "Malware"
 msgstr "惡意軟體"
 
 msgid "Manifest"
-msgstr "資訊"
+msgstr "清單檔案"
 
 msgid "Map"
-msgstr ""
+msgstr "地圖"
 
 msgid "Maps"
-msgstr ""
+msgstr "地圖"
 
 msgid "Mask"
-msgstr ""
+msgstr "遮罩"
 
 msgid "Match case"
 msgstr "區分大小寫"
 
 msgid "Matches"
-msgstr ""
+msgstr "符合"
 
 msgid "Maximum"
 msgstr "最大值"
 
 msgid "Memory"
-msgstr "記憶"
+msgstr "記憶體"
 
 msgid "Memory map"
 msgstr "記憶體區塊"
@@ -832,10 +832,10 @@ msgid "Mode"
 msgstr "模式"
 
 msgid "Modules"
-msgstr "模塊"
+msgstr "模組"
 
 msgid "More info"
-msgstr "更多信息"
+msgstr "更多資訊"
 
 msgid "Multiplatform"
 msgstr "跨平台"
@@ -859,22 +859,22 @@ msgid "Next"
 msgstr "下一個"
 
 msgid "Next visited"
-msgstr ""
+msgstr "下一個訪問的"
 
 msgid "No"
 msgstr "不"
 
 msgid "No update available"
-msgstr "無可用的更新"
+msgstr "沒有可用的更新"
 
 msgid "None"
 msgstr "無"
 
 msgid "Nothing found"
-msgstr "沒有找到"
+msgstr "找不到"
 
 msgid "Null-terminated"
-msgstr "以空字元結尾"
+msgstr "以空字元結尾的"
 
 msgid "Number"
 msgstr "數字"
@@ -895,7 +895,7 @@ msgid "Offset"
 msgstr "偏移"
 
 msgid "One operand"
-msgstr "一個運算元"
+msgstr "一個操作數"
 
 msgid "Online tools"
 msgstr "線上工具"
@@ -919,7 +919,7 @@ msgid "Open file"
 msgstr "打開檔案"
 
 msgid "Operation system"
-msgstr "操作系統"
+msgstr "作業系統"
 
 msgid "Options"
 msgstr "選項"
@@ -931,10 +931,10 @@ msgid "Overlay"
 msgstr "覆蓋"
 
 msgid "Package"
-msgstr ""
+msgstr "套件"
 
 msgid "Packer"
-msgstr "封隔器"
+msgstr "包裝器"
 
 msgid "Patch"
 msgstr "修補"
@@ -943,13 +943,13 @@ msgid "Pause"
 msgstr "暫停"
 
 msgid "Paused"
-msgstr "暫停"
+msgstr "已暫停"
 
 msgid "Payload"
-msgstr ""
+msgstr "有效負載"
 
 msgid "Plain Text"
-msgstr ""
+msgstr "明文"
 
 msgid "Platform"
 msgstr "平台"
@@ -958,31 +958,31 @@ msgid "Player"
 msgstr "播放器"
 
 msgid "Please restart the application"
-msgstr "請重啟應用程式"
+msgstr "請重新啟動應用程式"
 
 msgid "Please run the program as an administrator"
-msgstr "請以管理員身份運行程序"
+msgstr "請以管理員身份執行程式"
 
 msgid "Please use valid API key"
 msgstr "請使用有效的API金鑰"
 
 msgid "Pointer"
-msgstr "指針"
+msgstr "指標"
 
 msgid "Previous visited"
-msgstr ""
+msgstr "上次造訪過的"
 
 msgid "Print"
-msgstr "打印"
+msgstr "列印"
 
 msgid "Process"
 msgstr "處理"
 
 msgid "Profiling"
-msgstr ""
+msgstr "性能分析"
 
 msgid "Program name"
-msgstr "程序名稱"
+msgstr "程式名稱"
 
 msgid "Programs"
 msgstr "程式"
@@ -1000,7 +1000,7 @@ msgid "Prototype"
 msgstr "原型"
 
 msgid "Publisher"
-msgstr "出版商"
+msgstr "發行者"
 
 msgid "Raw data"
 msgstr "原始資料"
@@ -1012,10 +1012,10 @@ msgid "Readonly"
 msgstr "唯讀"
 
 msgid "Rebase"
-msgstr "變基"
+msgstr "變更基底位址"
 
 msgid "Recent files"
-msgstr "最近的檔案"
+msgstr "最近用過的檔案"
 
 msgid "Recursive"
 msgstr "遞迴"
@@ -1024,16 +1024,16 @@ msgid "Recursive scan"
 msgstr "遞歸掃描"
 
 msgid "Ref from"
-msgstr "從何堤及"
+msgstr "從何引用"
 
 msgid "Ref to"
-msgstr "提及於"
+msgstr "引用於"
 
 msgid "References"
 msgstr "引用"
 
 msgid "Region"
-msgstr "地區"
+msgstr "區域"
 
 msgid "Regions"
 msgstr "區域"
@@ -1057,7 +1057,7 @@ msgid "Reload"
 msgstr "重新載入"
 
 msgid "Relocs"
-msgstr "重新定位"
+msgstr "重定位"
 
 msgid "Remove"
 msgstr "移除"
@@ -1096,10 +1096,10 @@ msgid "Running"
 msgstr "正在執行"
 
 msgid "Runtime driver"
-msgstr "運行時驅動程序"
+msgstr "執行時期驅動程式"
 
 msgid "Save"
-msgstr "保存"
+msgstr "存檔"
 
 msgid "Save as"
 msgstr "另存新檔"
@@ -1138,7 +1138,7 @@ msgid "Scan for IAT"
 msgstr "搜尋 IAT"
 
 msgid "Schema"
-msgstr ""
+msgstr "架構"
 
 msgid "Script"
 msgstr "腳本"
@@ -1153,7 +1153,7 @@ msgid "Search from"
 msgstr "搜尋位置"
 
 msgid "Search signature"
-msgstr ""
+msgstr "搜尋簽名"
 
 msgid "Search signatures"
 msgstr "搜尋簽名"
@@ -1171,22 +1171,22 @@ msgid "Search values"
 msgstr "搜尋值"
 
 msgid "Section"
-msgstr "部分"
+msgstr "節"
 
 msgid "Section name"
-msgstr "分段名稱"
+msgstr "節名稱"
 
 msgid "Sections"
-msgstr "部分"
+msgstr "節"
 
 msgid "Segment"
-msgstr "分段"
+msgstr "段"
 
 msgid "Segment registers"
-msgstr "分段暫存器"
+msgstr "段暫存器"
 
 msgid "Segments"
-msgstr "分段"
+msgstr "段"
 
 msgid "Select"
 msgstr "選擇"
@@ -1222,13 +1222,13 @@ msgid "Show detects"
 msgstr "顯示偵測"
 
 msgid "Show in"
-msgstr ""
+msgstr "顯示於"
 
 msgid "Show info"
 msgstr "顯示資訊"
 
 msgid "Show logo"
-msgstr "顯示徽標"
+msgstr "顯示標誌"
 
 msgid "Show type"
 msgstr "顯示型態"
@@ -1276,7 +1276,7 @@ msgid "Sorted"
 msgstr "已排序"
 
 msgid "Source code"
-msgstr "源代碼"
+msgstr "原始碼"
 
 msgid "Spaces"
 msgstr "空格"
@@ -1309,7 +1309,7 @@ msgid "String"
 msgstr "字串"
 
 msgid "String table"
-msgstr "字符串表"
+msgstr "字串表"
 
 msgid "Strings"
 msgstr "字串"
@@ -1357,7 +1357,7 @@ msgid "Table of contents"
 msgstr "目錄"
 
 msgid "Table views"
-msgstr ""
+msgstr "表格視圖"
 
 msgid "Tags"
 msgstr "標籤"
@@ -1396,7 +1396,7 @@ msgid "The value copied to clipboard"
 msgstr "值已複製到剪貼版"
 
 msgid "Threads"
-msgstr "線程"
+msgstr "執行緒"
 
 msgid "TiB"
 msgstr "TiB"
@@ -1423,25 +1423,25 @@ msgid "Total"
 msgstr "總計"
 
 msgid "Trace"
-msgstr "追蹤"
+msgstr "跟蹤"
 
 msgid "Trace into"
-msgstr "步入"
+msgstr "跟蹤進入"
 
 msgid "Trace over"
-msgstr "步過"
+msgstr "跟蹤步過"
 
 msgid "Tree"
 msgstr "樹狀圖"
 
 msgid "Tree views"
-msgstr ""
+msgstr "樹狀視圖"
 
 msgid "Trojan"
 msgstr "木馬"
 
 msgid "Two operands"
-msgstr "兩個運算元"
+msgstr "兩個操作數"
 
 msgid "Type"
 msgstr "類型"
@@ -1492,7 +1492,7 @@ msgid "Video"
 msgstr "影片"
 
 msgid "View"
-msgstr "看法"
+msgstr "查看"
 
 msgid "Viewer"
 msgstr "查看器"
@@ -1534,7 +1534,7 @@ msgid "Zoom"
 msgstr "縮放"
 
 msgid "compressor"
-msgstr "壓縮軟件"
+msgstr "壓縮器"
 
 msgid "data"
 msgstr "資料"
@@ -1555,7 +1555,7 @@ msgid "not packed"
 msgstr "未打包"
 
 msgid "obfuscator"
-msgstr "模糊器"
+msgstr "混淆器"
 
 msgid "packed"
 msgstr "已打包"


### PR DESCRIPTION
Hello, horsicq:
I have populated all entries in `dict_zh-TW.po`, but I've also identified some potential ambiguities that could result in incorrect translations:
1. "Map" and "Maps":
     - (noun) A detailed representation of a region on a flat surface.
     - (verb) To establish a correspondence between the members of one set and those of another.
2. "Search signature" and "Search signatures":
     - Search for a specific pattern
     - Search for a cryptographic signature

Could you clarify where these messages are used please?